### PR TITLE
Add NoGood attribution for SEC-03, SEC-04, and SEC-05 designs

### DIFF
--- a/src/pages/swag.astro
+++ b/src/pages/swag.astro
@@ -219,6 +219,9 @@ import Base from "@/layouts/Base.astro";
                 with a simple, open protocol like nostr, ecash is not just viable; it's a match made in
                 heaven, ready to power a new generation of sovereign applications.
               </p>
+              <p class="text-sm text-gray-400 italic">
+                Design by <a href="https://npub.world/npub12hcytyr8fumy3axde8wgeced523gyp6v6zczqktwuqeaztfc2xzsz3rdp4" target="_blank" rel="noopener noreferrer" class="underline hover:text-white transition-colors">NoGood</a>
+              </p>
             </div>
           </div>
         </div>
@@ -284,6 +287,9 @@ import Base from "@/layouts/Base.astro";
                 trade-offs, not wishful thinking. Understanding these constraints is the first step to
                 overcoming them.
               </p>
+              <p class="text-sm text-gray-400 italic">
+                Design by <a href="https://npub.world/npub12hcytyr8fumy3axde8wgeced523gyp6v6zczqktwuqeaztfc2xzsz3rdp4" target="_blank" rel="noopener noreferrer" class="underline hover:text-white transition-colors">NoGood</a>
+              </p>
             </div>
           </div>
         </div>
@@ -344,6 +350,9 @@ import Base from "@/layouts/Base.astro";
                 only uncensorable but also aligned with our vision of a freer, more sovereign future.
                 This shirt is a declaration that we're not here to reform the old system; we're here to
                 make it obsolete.
+              </p>
+              <p class="text-sm text-gray-400 italic">
+                Design by <a href="https://npub.world/npub12hcytyr8fumy3axde8wgeced523gyp6v6zczqktwuqeaztfc2xzsz3rdp4" target="_blank" rel="noopener noreferrer" class="underline hover:text-white transition-colors">NoGood</a>
               </p>
             </div>
           </div>


### PR DESCRIPTION
This PR adds proper attribution to NoGood for the design work on SEC-03 (Ecash), SEC-04 (Trilemmas), and SEC-05 (YOLO Mode) swag items. Each design now includes a small italicized credit line linking to [NoGood's profile](https://npub.world/npub12hcytyr8fumy3axde8wgeced523gyp6v6zczqktwuqeaztfc2xzsz3rdp4) at npub.world. The attributions are styled consistently with the existing design and positioned at the end of each product description.