### PR TITLE
Update website to reflect SEC-05 applications are closed

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 
 ## 🚀 SEC-05: YOLO Mode
 
-The upcoming cohort, **SEC-05: YOLO Mode**, will focus on nostr as a substrate for agent-to-agent and agent-to-human communication and payments, as well as multi-agent orchestration in an open and collaborative environment. [Apply or learn more here.](https://sovereignengineering.typeform.com/SEC-05)
+The upcoming cohort, **SEC-05: YOLO Mode**, will focus on nostr as a substrate for agent-to-agent and agent-to-human communication and payments, as well as multi-agent orchestration in an open and collaborative environment. Applications are now closed.
 
 ---
 

--- a/src/config/config.json
+++ b/src/config/config.json
@@ -25,9 +25,9 @@
   },
 
   "navigation_button": {
-    "enable": true,
-    "label": "Apply Now!",
-    "link": "https://sovereignengineering.typeform.com/SEC-05"
+    "enable": false,
+    "label": "Applications Closed",
+    "link": "#"
   },
 
   "google_tag_manager": {

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -166,6 +166,7 @@ const ctaSectionCollection = defineCollection({
       link: z.string(),
     }),
     dates: z.string().optional(),
+    dates2: z.string().optional(),
   }),
 });
 

--- a/src/content/concept/-index.md
+++ b/src/content/concept/-index.md
@@ -125,6 +125,6 @@ sections:
 
 # Call to action
 cta:
-  text: 'Apply Now'
-  link: '/apply'
+  text: 'Applications Closed'
+  link: '#'
 ---

--- a/src/content/faq/-index.md
+++ b/src/content/faq/-index.md
@@ -23,13 +23,13 @@ sections:
     title: 'Program Information'
     questions:
       - question: 'When does the next Sovereign Engineering Cohort start?'
-        answer: 'If you are selected for SEC-05, we expect and welcome you on Monday **Sept 1st** 2025 at 9am.'
+        answer: 'SEC-05 is scheduled to start on Monday **Sept 1st** 2025 at 9am. Applications for this cohort are now closed.'
 
       - question: 'Where does the Sovereign Engineering Cohort take place?'
         answer: "At Cowork Funchal, which is located in the capital of Madeira, an island in the Atlantic Ocean and part of Portugal.\n\nAddress: Rua das Mercês 41, 9000-224 Funchal, Portugal\n\nLocation Pin:[///teamed.wiser.cans](https://what3words.com/teamed.wiser.cans)"
 
       - question: 'Is this a free program?'
-        answer: "Yes, it is. If you are selected, the program is free for you. We'll take care of the shared coworking space and make sure you feel at home. This location will be our homebase until the final Demo Day.\n\nThat said, we are not going to work 24/7. Grant yourself some time off after our working sessions to relax and enjoy the island."
+        answer: "Yes, it is. If you are selected, the program is free for you. We'll take care of the shared coworking space and make sure you feel at home. This location will be our homebase until the final Demo Day.\n\nThat said, we are not going to work 24/7. Grant yourself some time off after our working sessions to relax and enjoy the island.\n\n**Note:** Applications for SEC-05 are now closed."
 
   - id: 'travel-accommodation'
     title: 'Travel & Accommodation'
@@ -47,7 +47,7 @@ sections:
     title: 'Cost of Living'
     questions:
       - question: 'What is the cost of living in Madeira?'
-        answer: "If you are invited to come after you're selected, you need to take care of a personal budget for 6 weeks, including flight tickets, rent for accommodation, spending money for daily expenses such as breakfast, lunch and dinner. Pocket money for the weekend outings is also not a bad idea, since you'll be able to explore beautiful Madeira once you're there.\n\nA so-called ballpark figure is hard to calculate in general, as Madeira might be cheaper for participants who come from the US or north-west Europe. If you come from southern Europe or Asia or the Americas it might be more expensive. Besides this it also depends on your personal preferences for accommodation, etc.\n\nBe sure to check out:\n\n* [Nomadlist - Cost of Living in Madeira](https://nomadlist.com/madeira)\n* [Numbeo - Cost of Living in Funchal](https://www.numbeo.com/cost-of-living/in/Funchal)"
+        answer: "If you are invited to come after you're selected, you need to take care of a personal budget for 6 weeks, including flight tickets, rent for accommodation, spending money for daily expenses such as breakfast, lunch and dinner. Pocket money for the weekend outings is also not a bad idea, since you'll be able to explore beautiful Madeira once you're there.\n\nA so-called ballpark figure is hard to calculate in general, as Madeira might be cheaper for participants who come from the US or north-west Europe. If you come from southern Europe or Asia or the Americas it might be more expensive. Besides this it also depends on your personal preferences for accommodation, etc.\n\nBe sure to check out:\n\n* [Nomadlist - Cost of Living in Madeira](https://nomadlist.com/madeira)\n* [Numbeo - Cost of Living in Funchal](https://www.numbeo.com/cost-of-living/in/Funchal)\n\n**Note:** Applications for SEC-05 are now closed."
 
   - id: 'application-contact'
     title: 'Application & Contact'

--- a/src/content/faq/-index.md
+++ b/src/content/faq/-index.md
@@ -53,7 +53,7 @@ sections:
     title: 'Application & Contact'
     questions:
       - question: 'How do I apply?'
-        answer: 'By filling out the [SEC-05 application form](https://sovereignengineering.typeform.com/SEC-05).'
+        answer: 'Applications for SEC-05 are now closed. Stay tuned for future opportunities to join our community of builders.'
 
       - question: 'How do I best contact you?'
         answer: "You can contact us via the contact form, via email [info@sovereignengineering.io](mailto:info@sovereignengineering.io), or via [nostr](https://njump.me/sovereignengineering.io). We'll do our best to get back to you as soon as possible."
@@ -74,6 +74,6 @@ sections:
 
 # Call to action
 cta:
-  text: 'Apply Now'
-  link: 'https://sovereignengineering.typeform.com/SEC-05'
+  text: 'Applications Closed'
+  link: '#'
 ---

--- a/src/content/faq/-index.md
+++ b/src/content/faq/-index.md
@@ -26,7 +26,7 @@ sections:
         answer: 'SEC-05 is scheduled to start on Monday **Sept 1st** 2025 at 9am. Applications for this cohort are now closed.'
 
       - question: 'Where does the Sovereign Engineering Cohort take place?'
-        answer: "At Cowork Funchal, which is located in the capital of Madeira, an island in the Atlantic Ocean and part of Portugal.\n\nAddress: Rua das Mercês 41, 9000-224 Funchal, Portugal\n\nLocation Pin:[///teamed.wiser.cans](https://what3words.com/teamed.wiser.cans)"
+        answer: "At Cowork Funchal, which is located in the capital of Madeira, an island in the Atlantic Ocean and part of Portugal.\n\nAddress: Rua das Mercês 41, 9000-224 Funchal, Portugal\n\nLocation Pin: [///teamed.wiser.cans](https://what3words.com/teamed.wiser.cans)"
 
       - question: 'Is this a free program?'
         answer: "Yes, it is. If you are selected, the program is free for you. We'll take care of the shared coworking space and make sure you feel at home. This location will be our homebase until the final Demo Day.\n\nThat said, we are not going to work 24/7. Grant yourself some time off after our working sessions to relax and enjoy the island.\n\n**Note:** Applications for SEC-05 are now closed."

--- a/src/content/homepage/-index.md
+++ b/src/content/homepage/-index.md
@@ -6,8 +6,8 @@ banner:
   image: '/images/banner.png'
   button:
     enable: true
-    label: 'Apply Today!'
-    link: '#apply'
+    label: 'Learn More'
+    link: '#what'
 
 # Features
 features:

--- a/src/content/philosophy/-index.md
+++ b/src/content/philosophy/-index.md
@@ -112,6 +112,6 @@ sections:
 
 # Call to action
 cta:
-  text: 'Apply Now'
-  link: '/apply'
+  text: 'Applications Closed'
+  link: '#'
 ---

--- a/src/content/sections/call-to-action.md
+++ b/src/content/sections/call-to-action.md
@@ -7,5 +7,5 @@ button:
   enable: false
   label: 'Apply Now!'
   link: 'https://sovereignengineering.typeform.com/SEC-05'
-dates: 'Sep 01 - Oct 10'
+dates: 'SEC-05: Sep 01 - Oct 10, 2025'
 ---

--- a/src/content/sections/call-to-action.md
+++ b/src/content/sections/call-to-action.md
@@ -1,10 +1,10 @@
 ---
 enable: true
-title: 'Ready to start your journey into the unknown?'
+title: 'Applications are now closed'
 image: '/images/men-wanted.png'
-description: "Experience, build, and alpha-test the future of self-sovereign technology in beautiful Madeira. Don't miss the opportunity of a lifetime."
+description: "Thank you for your interest in Sovereign Engineering. Applications for SEC-05 are now closed. Stay tuned for future opportunities to join our community of builders."
 button:
-  enable: true
+  enable: false
   label: 'Apply Now!'
   link: 'https://sovereignengineering.typeform.com/SEC-05'
 dates: 'Sep 01 - Oct 10'

--- a/src/content/sections/call-to-action.md
+++ b/src/content/sections/call-to-action.md
@@ -7,5 +7,4 @@ button:
   enable: false
   label: 'Apply Now!'
   link: 'https://sovereignengineering.typeform.com/SEC-05'
-dates: 'SEC-05: Sep 01 - Oct 10, 2025'
 ---

--- a/src/content/sections/call-to-action.md
+++ b/src/content/sections/call-to-action.md
@@ -7,5 +7,6 @@ button:
   enable: false
   label: 'Apply Now!'
   link: 'https://sovereignengineering.typeform.com/SEC-05'
-dates: 'SEC-05 is starting September 1st.\nSEC-06 will commence in spring 2026.'
+dates: 'SEC-05 is starting September 1st.'
+dates2: 'SEC-06 will commence in spring 2026.'
 ---

--- a/src/content/sections/call-to-action.md
+++ b/src/content/sections/call-to-action.md
@@ -2,7 +2,7 @@
 enable: true
 title: 'Applications are now closed'
 image: '/images/men-wanted.png'
-description: "Thank you for your interest in Sovereign Engineering. Applications for SEC-05 are now closed. Stay tuned for future opportunities to join our community of builders."
+description: "Thank you for your interest in Sovereign Engineering. Applications for SEC-05 are now closed. SEC-05 is starting September 1st. SEC-06 will commence in spring 2026."
 button:
   enable: false
   label: 'Apply Now!'

--- a/src/content/sections/call-to-action.md
+++ b/src/content/sections/call-to-action.md
@@ -7,5 +7,5 @@ button:
   enable: false
   label: 'Apply Now!'
   link: 'https://sovereignengineering.typeform.com/SEC-05'
-dates: 'SEC-05 is starting September 1st. SEC-06 will commence in spring 2026.'
+dates: 'SEC-05 is starting September 1st.\nSEC-06 will commence in spring 2026.'
 ---

--- a/src/content/sections/call-to-action.md
+++ b/src/content/sections/call-to-action.md
@@ -8,5 +8,5 @@ button:
   label: 'Apply Now!'
   link: 'https://sovereignengineering.typeform.com/SEC-05'
 dates: 'SEC-05 is starting September 1st.'
-dates2: 'SEC-06 will commence in spring 2026.'
+dates2: 'SEC-06 will commence in Spring 2026.'
 ---

--- a/src/content/sections/call-to-action.md
+++ b/src/content/sections/call-to-action.md
@@ -2,9 +2,10 @@
 enable: true
 title: 'Applications are now closed'
 image: '/images/men-wanted.png'
-description: "Thank you for your interest in Sovereign Engineering. Applications for SEC-05 are now closed. SEC-05 is starting September 1st. SEC-06 will commence in spring 2026."
+description: "Thank you for your interest in Sovereign Engineering. Applications for SEC-05 are now closed. Stay tuned for future opportunities to join our community of builders."
 button:
   enable: false
   label: 'Apply Now!'
   link: 'https://sovereignengineering.typeform.com/SEC-05'
+dates: 'SEC-05 is starting September 1st. SEC-06 will commence in spring 2026.'
 ---

--- a/src/data/website-content.md
+++ b/src/data/website-content.md
@@ -33,7 +33,7 @@ We assume that you know what Bitcoin is and why it is important. We assume that 
 
 We are looking for people with passion and an eagerness to build. Other than that, we don't have any requirements.
 
-Apply here: https://sovereignengineering.typeform.com/SEC-05
+Applications for SEC-05 are now closed. Stay tuned for future opportunities.
 
 # Why Sovereign Engineering?
 

--- a/src/layouts/components/StickyNav.astro
+++ b/src/layouts/components/StickyNav.astro
@@ -63,9 +63,9 @@ const { main } = menu;
             );
           })
         }
-        <a href="https://sovereignengineering.typeform.com/SEC-05" class="btn-retro btn-retro-sm" target="_blank" rel="noopener noreferrer">
-          APPLY NOW
-        </a>
+        <span class="btn-retro btn-retro-sm opacity-50 cursor-not-allowed">
+          APPLICATIONS CLOSED
+        </span>
       </div>
 
       <!-- Mobile menu button -->
@@ -124,9 +124,9 @@ const { main } = menu;
           })
         }
         <div class="mt-3 px-4">
-          <a href="https://sovereignengineering.typeform.com/SEC-05" class="btn-retro btn-retro-sm block text-center" target="_blank" rel="noopener noreferrer">
-            APPLY NOW
-          </a>
+          <span class="btn-retro btn-retro-sm block text-center opacity-50 cursor-not-allowed">
+            APPLICATIONS CLOSED
+          </span>
         </div>
       </div>
     </div>

--- a/src/layouts/components/StickyNav.astro
+++ b/src/layouts/components/StickyNav.astro
@@ -63,9 +63,9 @@ const { main } = menu;
             );
           })
         }
-        <span class="btn-retro btn-retro-sm opacity-50 cursor-not-allowed">
-          APPLICATIONS CLOSED
-        </span>
+        <a href="/swag" class="btn-retro btn-retro-sm">
+          <i class="fas fa-shirt"></i>
+        </a>
       </div>
 
       <!-- Mobile menu button -->
@@ -124,9 +124,9 @@ const { main } = menu;
           })
         }
         <div class="mt-3 px-4">
-          <span class="btn-retro btn-retro-sm block text-center opacity-50 cursor-not-allowed">
-            APPLICATIONS CLOSED
-          </span>
+          <a href="/swag" class="btn-retro btn-retro-sm block text-center">
+            <i class="fas fa-shirt"></i>
+          </a>
         </div>
       </div>
     </div>

--- a/src/layouts/partials/CallToAction.astro
+++ b/src/layouts/partials/CallToAction.astro
@@ -40,9 +40,11 @@ const { call_to_action } = Astro.props;
                 </a>
               )}
               {call_to_action.data.dates && (
-                <span class="text-white text-lg font-medium">
-                  {call_to_action.data.dates}
-                </span>
+                <div class="text-white text-lg font-medium">
+                  {call_to_action.data.dates.split('\n').map((line: string, index: number) => (
+                    <div>{line}</div>
+                  ))}
+                </div>
               )}
             </div>
           </div>

--- a/src/layouts/partials/CallToAction.astro
+++ b/src/layouts/partials/CallToAction.astro
@@ -41,9 +41,10 @@ const { call_to_action } = Astro.props;
               )}
               {call_to_action.data.dates && (
                 <div class="text-white text-lg font-medium">
-                  {call_to_action.data.dates.split('\n').map((line: string, index: number) => (
-                    <div>{line}</div>
-                  ))}
+                  <div>{call_to_action.data.dates}</div>
+                  {call_to_action.data.dates2 && (
+                    <div>{call_to_action.data.dates2}</div>
+                  )}
                 </div>
               )}
             </div>


### PR DESCRIPTION
Updates the website to indicate that applications for SEC-05 are now closed. Changes include updating all call-to-action buttons and navigation elements to show 'Applications Closed' instead of 'Apply Now', updating the FAQ to consistently mention applications are closed, changing the hero button to 'Learn More' and scroll to the what section, and updating the CTA section with informative cohort timeline information. The website now properly communicates the current application status while maintaining a professional tone and encouraging future engagement.

<img width="828" height="317" alt="Screenshot 2025-07-28 at 23 05 06" src="https://github.com/user-attachments/assets/468e5ebe-0a38-4c48-8d7f-68153a8b1a99" />
