### PR TITLE
Refine copy and navigation: Philosophy/Concept/Loop, link flow, and tone cleanup

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -53,6 +53,7 @@ const philosophyCollection = defineCollection({
         float: z.string(),
         content: z.string(),
         link: z.string().optional(),
+        afterContent: z.string().optional(),
       }),
     ),
     cta: z.object({
@@ -80,6 +81,7 @@ const conceptCollection = defineCollection({
         content: z.string(),
         image: z.string().optional(),
         float: z.string().optional(),
+        afterContent: z.string().optional(),
       }),
     ),
     cta: z.object({

--- a/src/content/concept/-index.md
+++ b/src/content/concept/-index.md
@@ -123,7 +123,7 @@ sections:
       **The Goal**: We want to see awesome stuff being built, expand the impact that freedom tech can have, come up with new ideas and protocols, test them immediately, and have a good time while doing it.
     image: 'stay-weird.jpg'
     afterContent: |
-      <p class="mt-6 text-center"><a href="/loop">Next: See the Weekly Loop →</a></p>
+      <p class="mt-6"><a href="/loop">Next: See the Weekly Loop →</a></p>
 
 # Call to action
 cta:

--- a/src/content/concept/-index.md
+++ b/src/content/concept/-index.md
@@ -45,7 +45,7 @@ sections:
 
       **Why Walking Works**: Research shows walking stimulates creative thought. As one participant put it: "left foot, right foot, left brain, right brain." The physical movement activates your whole being and creates the perfect conditions for free-flowing ideas.
 
-      The island's levadas, coastal paths, and high-altitude ridges offer constantly changing scenery—nature's own slide deck. Exposure to sun, wind, and ocean spray anchors discussions in sensory memory; participants can later reference "that idea above the cloud layer" and everyone knows the exact moment.
+      The island's levadas, coastal paths, and high-altitude ridges offer constantly changing scenery—nature's own slide deck. The sensory experience of sun, wind, and ocean spray anchors discussions in memory, making ideas easier to recall and reference later.
     image: 'walking.jpeg'
     float: 'right'
 

--- a/src/content/concept/-index.md
+++ b/src/content/concept/-index.md
@@ -11,7 +11,7 @@ intro:
 
       The program runs on a relentless [weekly loop](/loop) designed for exploration: *Monday Mornings* set the theme for the week, *Tuesday Talks* provoke discussion, *Wednesday Workshops* transfer hands-on skills, *Thursday* offers time for reflection and experimentation, and by Friday's Demo Day every participant has completed an entire **show → talk → build** loop—ready to reset and do it again the following week.
 
-      The program is **private and off the record**—a protected environment where 21 value-aligned builders can think freely, experiment boldly, and ship rapidly without the constraints of public scrutiny. Bring 21 aligned people together in a place that is highly Bitcoin-friendly and beautiful, where a shift in perspective helps new ideas flourish—and remarkable things follow.
+      The program is **private and off the record**—a protected environment where value-aligned builders can think freely, experiment boldly, and ship rapidly without the constraints of public scrutiny. Bring 21 aligned people together in a place that is highly Bitcoin-friendly and beautiful, where a shift in perspective helps new ideas flourish—and remarkable things follow.
   image: 'www-life-path.png'
 
 # Concept sections

--- a/src/content/concept/-index.md
+++ b/src/content/concept/-index.md
@@ -56,9 +56,9 @@ sections:
 
       **The Format**: Aggressively time-boxed with 6 minutes of demo time and 2 minutes of discussion. With 20+ demos, we take breaks after every 6-7 presentations, usually running three sessions. The day typically ends around 6 PM.
 
-      **The Philosophy**: We highly encourage trying crazy ideas every week. It doesn't matter if it's half-broken or half-baked—just give it your best shot and show it on Friday. This prevents "strudelutions" by forcing thin vertical slices over speculative architecture.
+      **The Philosophy**: We highly encourage trying bold ideas every week. It doesn't matter if it's half-broken or half-baked—just give it your best shot and show it on Friday. The point is to ship thin vertical slices and learn fast.
 
-      **The Celebration**: After demos, we have a standing barbecue (no pre-arranged seating) that encourages natural group mixing. Friends and family are invited to join, creating a bridge between the private program and the broader community.
+      **The Celebration**: After demos, we have a [beefsteak-style](https://archive.is/S3LjP) standing barbecue (no pre-arranged seating) that encourages natural group mixing. Friends and family are invited to join, creating a bridge between the private program and the broader community.
 
       **The Impact**: Demo Day serves as a public ledger of progress. Six Fridays equal six checkpoints, creating proof-of-work encoded in weekly commits that prospective participants can review.
     image: 'demo-day.jpeg'

--- a/src/content/concept/-index.md
+++ b/src/content/concept/-index.md
@@ -45,12 +45,6 @@ sections:
 
       **Why Walking Works**: Research shows walking stimulates creative thought. As one participant put it: "left foot, right foot, left brain, right brain." The physical movement activates your whole being and creates the perfect conditions for free-flowing ideas.
 
-      **Natural Group Mixing**: With 21 participants, the walks naturally mix the group. You'll have many different conversational partners during a three-hour walk. Two guides—one at the front, one at the back—ensure the group stays together by stopping every 20 minutes to enjoy views, take water breaks, and let everyone catch up.
-
-      **The Alternative**: Contrast this with sitting around a long table for dinner—you'd have at most three conversational partners (left, right, front) and the group wouldn't mix. Walking creates the natural group formation and spontaneous conversations we need.
-
-      **The Path Requirements**: Paths must be wide enough for side-by-side walking (not single-file), mostly flat so anyone can participate, and comfortable enough for conversation. Guides keep the group together, stopping regularly to let everyone catch up.
-
       The island's levadas, coastal paths, and high-altitude ridges offer constantly changing scenery—nature's own slide deck. Exposure to sun, wind, and ocean spray anchors discussions in sensory memory; participants can later reference "that idea above the cloud layer" and everyone knows the exact moment.
     image: 'walking.jpeg'
     float: 'right'

--- a/src/content/concept/-index.md
+++ b/src/content/concept/-index.md
@@ -21,15 +21,15 @@ sections:
     content: |
       Sovereign Engineering rests on five fundamental pillars that create the conditions for meaningful collaboration:
 
-      **[The Weekly Loop](#weekly-loop)**: A steady show → talk → build rhythm that drives momentum and prevents perfectionism paralysis. Every week follows the same structure—a metronome for creativity.
+      **[The Weekly Loop](/loop#weekly-loop)**: A steady show → talk → build rhythm that drives momentum and prevents perfectionism paralysis. Every week follows the same structure—a metronome for creativity.
 
-      **[The Walks](#walks)**: Moderate hikes that stimulate creative thought through "left foot, right foot, left brain, right brain" activation. Walking isn't downtime—it's moving R&D.
+      **[The Walks](/loop#walks)**: Moderate hikes that stimulate creative thought through "left foot, right foot, left brain, right brain" activation. Walking isn't downtime—it's moving R&D.
 
-      **[The Demo Days](#demo-day)**: Where the rubber meets the road—every participant demos working code every week. Aggressively time-boxed with 6-minute demos and 2-minute discussions.
+      **[The Demo Days](/loop#demo-day)**: Where the rubber meets the road—every participant demos working code every week. Aggressively time-boxed with 6-minute demos and 2-minute discussions.
 
-      **[The Captains](#weekly-captains)**: Each week has a dedicated captain who steers the ship, ensuring organic emergence rather than top-down direction. Rotating leadership keeps the program tight without feeling top-down.
+      **[The Captains](/loop#captains)**: Each week has a dedicated captain who steers the ship, ensuring organic emergence rather than top-down direction. Rotating leadership keeps the program tight without feeling top-down.
 
-      **[The Environment](#environment)**: Madeira makes ideas tangible fast—Bitcoin-friendly merchants, high-bandwidth in-person time, and an off-the-record space for bold exploration. Privacy, presence, and immediacy compound.
+      **[The Environment](/loop#environment)**: Madeira makes ideas tangible fast—Bitcoin-friendly merchants, high-bandwidth in-person time, and an off-the-record space for bold exploration. Privacy, presence, and immediacy compound.
     image: '2-hours-of-conversation.jpeg'
 
   - id: 'weekly-loop'

--- a/src/content/concept/-index.md
+++ b/src/content/concept/-index.md
@@ -9,7 +9,7 @@ intro:
   content: |
       Sovereign Engineering is a six-week, in-person program on the island of Madeira. Its purpose is to create the best possible environment for **high-bandwidth ideation, collaboration, and rapid prototyping** around Freedom Tech such as Bitcoin, Lightning, and Nostr.
 
-      The program runs on a relentless [weekly loop](/loop) designed for exploration: Monday orientation sets the theme, *Tuesday Talks* provoke discussion, *Wednesday Workshops* transfer hands-on skills, *Thursday* offers time for reflection and experimentation, and by Friday's Demo Day every participant has completed an entire **show → talk → build** loop—ready to reset and do it again the following week.
+      The program runs on a relentless [weekly loop](/loop) designed for exploration: Monday mornings set the theme for the week, *Tuesday Talks* provoke discussion, *Wednesday Workshops* transfer hands-on skills, *Thursday* offers time for reflection and experimentation, and by Friday's Demo Day every participant has completed an entire **show → talk → build** loop—ready to reset and do it again the following week.
 
       The program is **private and off the record**—a safe space where 21 value-aligned builders can think freely, experiment boldly, and ship rapidly without the constraints of public scrutiny. Bring 21 aligned people together in a place that is highly Bitcoin-friendly and beautiful, where a shift in perspective helps new ideas flourish—and remarkable things follow.
   image: 'www-life-path.png'

--- a/src/content/concept/-index.md
+++ b/src/content/concept/-index.md
@@ -54,13 +54,13 @@ sections:
     content: |
       Nothing concentrates the mind like a live demo. Every Friday afternoon the cohort gathers to **show whatever runs**. Polish is optional, honesty is mandatory. The rule is simple: you must demo something new every week—either related to ongoing work or completely fresh ideas.
 
-      **The Format**: Aggressively time-boxed with 6 minutes of demo time and 2 minutes of discussion. With 20+ demos, we take breaks after every 6-7 presentations, usually running three sessions. The day typically ends around 6 PM.
+      **Format**: Aggressively time-boxed with 6 minutes of demo time and 2 minutes of discussion. With 20+ demos, we take breaks after every 6-7 presentations, usually running three sessions. The day typically ends around 6 PM.
 
-      **The Philosophy**: We highly encourage trying bold ideas every week. It doesn't matter if it's half-broken or half-baked—just give it your best shot and show it on Friday. The point is to ship thin vertical slices and learn fast.
+      **Philosophy**: We highly encourage trying bold ideas every week. It doesn't matter if it's half-broken or half-baked—just give it your best shot and show it on Friday. The point is to ship thin vertical slices and learn fast.
 
-      **The Celebration**: After demos, we have a [beefsteak-style](https://archive.is/S3LjP) standing barbecue (no pre-arranged seating) that invites relaxed, free-flowing conversation. Friends and family are invited to join, creating a bridge between the private program and the broader community.
+      **Celebration**: After demos, we have a [beefsteak-style](https://archive.is/S3LjP) standing barbecue (no pre-arranged seating) that invites relaxed, free-flowing conversation. Friends and family are invited to join, creating a bridge between the private program and the broader community.
 
-      **The Impact**: Demo Day serves as a public ledger of progress. Six Fridays equal six checkpoints, creating proof-of-work encoded in weekly commits that prospective participants can review.
+      **Impact**: Demo Day serves as a public ledger of progress. Six Fridays equal six checkpoints, creating proof-of-work encoded in weekly commits that prospective participants can review.
     image: 'demo-day.jpeg'
 
   

--- a/src/content/concept/-index.md
+++ b/src/content/concept/-index.md
@@ -9,7 +9,7 @@ intro:
   content: |
       Sovereign Engineering is a six-week, in-person program on the island of Madeira. Its purpose is to create the best possible environment for **high-bandwidth ideation, collaboration, and rapid prototyping** around Freedom Tech such as Bitcoin, Lightning, and Nostr.
 
-      The program runs on a relentless [weekly loop](/loop) designed for exploration: Monday mornings set the theme for the week, *Tuesday Talks* provoke discussion, *Wednesday Workshops* transfer hands-on skills, *Thursday* offers time for reflection and experimentation, and by Friday's Demo Day every participant has completed an entire **show → talk → build** loop—ready to reset and do it again the following week.
+      The program runs on a relentless [weekly loop](/loop) designed for exploration: *Monday Mornings* set the theme for the week, *Tuesday Talks* provoke discussion, *Wednesday Workshops* transfer hands-on skills, *Thursday* offers time for reflection and experimentation, and by Friday's Demo Day every participant has completed an entire **show → talk → build** loop—ready to reset and do it again the following week.
 
       The program is **private and off the record**—a safe space where 21 value-aligned builders can think freely, experiment boldly, and ship rapidly without the constraints of public scrutiny. Bring 21 aligned people together in a place that is highly Bitcoin-friendly and beautiful, where a shift in perspective helps new ideas flourish—and remarkable things follow.
   image: 'www-life-path.png'

--- a/src/content/concept/-index.md
+++ b/src/content/concept/-index.md
@@ -11,7 +11,7 @@ intro:
 
       The program runs on a relentless [weekly loop](/loop) designed for exploration: *Monday Mornings* set the theme for the week, *Tuesday Talks* provoke discussion, *Wednesday Workshops* transfer hands-on skills, *Thursday* offers time for reflection and experimentation, and by Friday's Demo Day every participant has completed an entire **show → talk → build** loop—ready to reset and do it again the following week.
 
-      The program is **private and off the record**—a protected environment where value-aligned builders can think freely, experiment boldly, and ship rapidly without the constraints of public scrutiny. Bring 21 aligned people together in a place that is highly Bitcoin-friendly and beautiful, where a shift in perspective helps new ideas flourish—and remarkable things follow.
+      The program is **private and off the record**—a protected environment where value-aligned builders can think freely, experiment boldly, and ship rapidly without the constraints of too much public scrutiny. Bring 21 aligned people together in a place that is highly Bitcoin-friendly and beautiful, where a shift in perspective helps new ideas flourish—and remarkable things follow.
   image: 'www-life-path.png'
 
 # Concept sections

--- a/src/content/concept/-index.md
+++ b/src/content/concept/-index.md
@@ -41,7 +41,7 @@ sections:
   - id: 'walks'
     title: 'The Walks'
     content: |
-      Walking isn't downtime—it's moving *R&D*. The weekend walks are the absolute core pillar of Sovereign Engineering, designed for light-to-moderate two- to three-hour hikes at a comfortable pace where participants can walk side-by-side and have conversations without breaking a sweat.
+      Walking isn't downtime—it's moving *R&D*. The weekend walks are a crucial component of Sovereign Engineering, designed for light-to-moderate two- to three-hour hikes at a comfortable pace where participants can walk side-by-side and have conversations without breaking a sweat.
 
       **Why Walking Works**: Research shows walking stimulates creative thought. As one participant put it: "left foot, right foot, left brain, right brain." The physical movement activates your whole being and creates the perfect conditions for free-flowing ideas.
 

--- a/src/content/concept/-index.md
+++ b/src/content/concept/-index.md
@@ -82,7 +82,7 @@ sections:
     title: 'The Environment'
     image: 'madeira.jpg'
     content: |
-      Madeira isn't just beautiful—it's a **Bitcoin-friendly proving ground**. Thanks to the efforts of André and FREE Madeira, there are 150+ merchants accepting Bitcoin. Paying in sats is normal.
+      Madeira isn't just beautiful—it's a **Bitcoin-friendly proving ground**. Thanks to the efforts of André and FREE Madeira, there are [150+ merchants](https://btcmap.org/community/free-madeira/merchants) accepting Bitcoin. Paying in sats is normal.
 
       **Off the Record, In Person**: We combine high-bandwidth in-person time with a private, off-the-record space. That safety lets wild ideas breathe before they ship to the open sea.
 

--- a/src/content/concept/-index.md
+++ b/src/content/concept/-index.md
@@ -9,7 +9,7 @@ intro:
   content: |
       Sovereign Engineering is a six-week, in-person program on the island of Madeira. Its purpose is to create the best possible environment for **high-bandwidth ideation, collaboration, and rapid prototyping** around Freedom Tech such as Bitcoin, Lightning, and Nostr.
 
-      This environment runs on a relentless weekly cadence designed for exploration: Monday orientation sets the theme, *Tuesday Talks* provoke discussion, *Wednesday Workshops* transfer hands-on skills, *Thursday* offers time for reflection and experimentation, and by Friday's Demo Day every participant has completed an entire **show → talk → build** loop—ready to reset and do it again the following week.
+      The program runs on a relentless [weekly loop](/loop) designed for exploration: Monday orientation sets the theme, *Tuesday Talks* provoke discussion, *Wednesday Workshops* transfer hands-on skills, *Thursday* offers time for reflection and experimentation, and by Friday's Demo Day every participant has completed an entire **show → talk → build** loop—ready to reset and do it again the following week.
 
       The program is **private and off the record**—a safe space where 21 value-aligned builders can think freely, experiment boldly, and ship rapidly without the constraints of public scrutiny. Bring 21 aligned people together in a place that is highly Bitcoin-friendly, beautiful, and conducive to spontaneous creation, and magical things follow.
   image: 'www-life-path.png'

--- a/src/content/concept/-index.md
+++ b/src/content/concept/-index.md
@@ -122,6 +122,8 @@ sections:
 
       **The Goal**: We want to see awesome stuff being built, expand the impact that freedom tech can have, come up with new ideas and protocols, test them immediately, and have a good time while doing it.
     image: 'stay-weird.jpg'
+    afterContent: |
+      <p class="mt-6 text-center"><a href="/loop">Next: See the Weekly Loop →</a></p>
 
 # Call to action
 cta:

--- a/src/content/concept/-index.md
+++ b/src/content/concept/-index.md
@@ -11,7 +11,7 @@ intro:
 
       The program runs on a relentless [weekly loop](/loop) designed for exploration: *Monday Mornings* set the theme for the week, *Tuesday Talks* provoke discussion, *Wednesday Workshops* transfer hands-on skills, *Thursday* offers time for reflection and experimentation, and by Friday's Demo Day every participant has completed an entire **show → talk → build** loop—ready to reset and do it again the following week.
 
-      The program is **private and off the record**—a safe space where 21 value-aligned builders can think freely, experiment boldly, and ship rapidly without the constraints of public scrutiny. Bring 21 aligned people together in a place that is highly Bitcoin-friendly and beautiful, where a shift in perspective helps new ideas flourish—and remarkable things follow.
+      The program is **private and off the record**—a protected environment where 21 value-aligned builders can think freely, experiment boldly, and ship rapidly without the constraints of public scrutiny. Bring 21 aligned people together in a place that is highly Bitcoin-friendly and beautiful, where a shift in perspective helps new ideas flourish—and remarkable things follow.
   image: 'www-life-path.png'
 
 # Concept sections

--- a/src/content/concept/-index.md
+++ b/src/content/concept/-index.md
@@ -7,11 +7,11 @@ description: 'Our concept and approach'
 # Main introduction section
 intro:
   content: |
-    Sovereign Engineering is a six-week, in-person program held on the island of Madeira. Its sole purpose is to create the best possible environment for **high-bandwidth ideation, collaboration, and rapid prototyping** around freedom-tech such as Bitcoin, Lightning, and Nostr.
+      Sovereign Engineering is a six-week, in-person program on the island of Madeira. Its purpose is to create the best possible environment for **high-bandwidth ideation, collaboration, and rapid prototyping** around Freedom Tech such as Bitcoin, Lightning, and Nostr.
 
-    This environment is powered by a relentless weekly cadence designed for exploration: *Monday Mornings* set the theme, *Tuesday Talks* provoke discussion, *Wednesday Workshops* transfer hands-on skills, *Thursday* offers time for reflection and experimentation, and by Friday's Demo Day, every participant has completed an entire **show → talk → build** loop—ready to reset and do it again the following week.
+      This environment runs on a relentless weekly cadence designed for exploration: Monday orientation sets the theme, *Tuesday Talks* provoke discussion, *Wednesday Workshops* transfer hands-on skills, *Thursday* offers time for reflection and experimentation, and by Friday's Demo Day every participant has completed an entire **show → talk → build** loop—ready to reset and do it again the following week.
 
-    The program is **private and off the record**—a safe space where 21 value-aligned builders can think freely, experiment boldly, and ship rapidly without the constraints of public scrutiny. When you bring 21 value-aligned people together in a place that's super Bitcoin-friendly, beautiful, and allows for spontaneous creation, magical things are bound to happen.
+      The program is **private and off the record**—a safe space where 21 value-aligned builders can think freely, experiment boldly, and ship rapidly without the constraints of public scrutiny. Bring 21 aligned people together in a place that is highly Bitcoin-friendly, beautiful, and conducive to spontaneous creation, and magical things follow.
   image: 'www-life-path.png'
 
 # Concept sections
@@ -25,9 +25,9 @@ sections:
 
       **The Walks**: Moderate hikes that stimulate creative thought through "left foot, right foot, left brain, right brain" activation. Walking isn't downtime—it's moving R&D.
 
-      **Friday Demo Days**: Where the rubber meets the road—every participant must demo working code every week, no exceptions. Aggressively time-boxed with 6-minute demos and 2-minute discussions.
+      **Friday Demo Days**: Where the rubber meets the road—every participant demos working code every week. Aggressively time-boxed with 6-minute demos and 2-minute discussions.
 
-      **Six Captains**: Each week has a dedicated captain who steers the ship, ensuring organic emergence rather than top-down direction. Leadership rotates, keeping the program tight without feeling top-down.
+      **Six Captains**: Each week has a dedicated captain who steers the ship, ensuring organic emergence rather than top-down direction. Rotating leadership keeps the program tight without feeling top-down.
 
       **In-Person Intensity**: Being physically present on a remote island creates the commitment and focus needed for deep work. High-bandwidth communication, trust building, and ideation only work in person.
     image: '2-hours-of-conversation.jpeg'
@@ -35,7 +35,7 @@ sections:
   - id: 'weekly-loop'
     title: 'The Weekly Loop'
     content: |
-      The week acts as a metronome for creativity. Friday's *Show* sets a hard deadline that concentrates effort—every participant must demo something they wrote or prompted into existence themselves. The moment code compiles on stage it becomes shared reality. Over the weekend and during Monday's orientation the cohort *Talks*—walking Madeira's levadas, swapping critiques, and letting distributed cognition surface better approaches. From Tuesday onwards everyone *Builds* toward the next demo.
+      The week acts as a metronome for creativity. Friday's *Show* sets a hard deadline that concentrates effort—every participant demos something they wrote or prompted into existence themselves. The moment code compiles on stage it becomes shared reality. Over the weekend and during Monday's orientation the cohort *Talks*—walking Madeira's levadas, swapping critiques, and letting distributed cognition surface better approaches. From Tuesday onward everyone *Builds* toward the next demo.
     image: 'show-talk-build-loop.jpeg'
 
   - id: 'walks'
@@ -49,7 +49,7 @@ sections:
 
       **The Alternative**: Contrast this with sitting around a long table for dinner—you'd have at most three conversational partners (left, right, front) and the group wouldn't mix. Walking creates the natural group formation and spontaneous conversations we need.
 
-      **The Path Requirements**: The path must be wide enough so people can walk next to each other (not single-file), mostly flat so anyone can participate, and comfortable enough that you can talk while walking. The guides must keep the group together and stop regularly to let everyone catch up.
+      **The Path Requirements**: Paths must be wide enough for side-by-side walking (not single-file), mostly flat so anyone can participate, and comfortable enough for conversation. Guides keep the group together, stopping regularly to let everyone catch up.
 
       The island's levadas, coastal paths, and high-altitude ridges offer constantly changing scenery—nature's own slide deck. Exposure to sun, wind, and ocean spray anchors discussions in sensory memory; participants can later reference "that idea above the cloud layer" and everyone knows the exact moment.
     image: 'walking.jpeg'
@@ -72,7 +72,7 @@ sections:
   - id: 'in-person-off-record'
     title: 'In Person, Off the Record'
     content: |
-      This is a **private, off the record event**—a core principle that cannot be overstated. You cannot do proper thinking completely out in the open. You have to be able to think in private and communicate in private without worrying about the online mob coming after you for having a crazy, weird, or stupid idea.
+      This is a **private, off-the-record event**—a core principle that cannot be overstated. You cannot do proper thinking completely out in the open. You have to be able to think in private and communicate in private without worrying about the online mob coming after you for having a crazy, weird, or stupid idea.
 
       **Why Privacy Matters**: We want to build out in the open and care deeply about open source, but ideation and experimentation require a safe space. You only want criticism from people who are actually on your side—otherwise you might destroy a gem of an idea too early.
 
@@ -86,10 +86,10 @@ sections:
   - id: 'weekly-captains'
     title: '6 Weeks, 6 Captains'
     content: |
-      Each week has a dedicated captain who steers the ship through that week's journey. The captain is the person who basically steers the ship through each week, ensuring organic emergence rather than top-down direction.
+      Each week has a dedicated captain who steers the ship through that week's journey, ensuring organic emergence rather than top-down direction.
 
-      **Captain Responsibilities**: 
-      Captain responsibilities include shepherding the walks by setting the conversational pace, choosing wide paths, and ensuring group mixing. Captains also time-box Friday demos, keep Monday orientations on track, organize Wednesday workshops and find time slots, arrange rooms appropriately for different activities (talks, workshops, demos), and give talks and presentations when appropriate.
+      **Captain Responsibilities**:
+      Shepherd the walks by setting the conversational pace, choosing wide paths, and ensuring group mixing. Time-box Friday demos, keep Monday orientations on track, organize Wednesday workshops and find time slots, and arrange rooms appropriately for different activities (talks, workshops, demos).
 
       **The Rotation**: By rotating leadership every week, the cohort practices the very autonomy it preaches. Leadership is shared, logistics are decentralized, and the program stays tight without feeling top-down.
 
@@ -100,25 +100,25 @@ sections:
     title: 'Madeira: The Bitcoin Island'
     image: 'madeira.jpg'
     content: |
-      Madeira isn't just a beautiful location—it's a **Bitcoin-friendly breeding ground** for the future. Thanks to the efforts of André and Free Madeira, there are 150+ merchants on the island accepting Bitcoin. It's so normal to pay in Bitcoin here that you don't even think about it anymore.
+      Madeira isn't just a beautiful location—it's a **Bitcoin-friendly breeding ground** for the future. Thanks to the efforts of André and FREE Madeira, there are 150+ merchants on the island accepting Bitcoin. Paying in Bitcoin is so normal here that you barely think about it.
 
-      **The Alpha Test Experience**: You can build a new wallet on Thursday, then go to the coffee shop on Friday and pay with the wallet you built yesterday. It works, and it's an amazing feeling. In some way, you can alpha test the future in Madeira.
+      **The Alpha Test Experience**: Build a new wallet on Thursday, then go to a coffee shop on Friday and pay with the wallet you built yesterday. It works—and it's an amazing feeling. In some ways, you can alpha test the future in Madeira.
 
       **The Filter Effect**: You can't just swing by and leave—you have to fly there. This creates a natural filter ensuring participants are committed to the full six-week experience.
 
-      **The Environment**: Madeira is a volcanic island with subtropical climate, dark volcanic cliffs, and breathtaking topography. It's a magical place that allows for the spontaneous creation of new things and the spawning of new ideas.
+      **The Environment**: Madeira is a volcanic island with a subtropical climate, dark volcanic cliffs, and breathtaking topography. It's a magical place that enables spontaneous creation and the spawning of new ideas.
 
-      **The Community**: There are many Bitcoiners on the island, and the merchant adoption is through the roof. It's a fantastic place to run a Sovereign Engineering cohort because it's super Bitcoin-friendly and allows immediate testing of new protocols and tools.
+      **The Community**: There are many Bitcoiners on the island, and merchant adoption is through the roof. It's a fantastic place to run a Sovereign Engineering cohort because it's highly Bitcoin-friendly and allows immediate testing of new protocols and tools.
 
   - id: 'target-audience'
     title: 'Who Should Apply?'
     content: |
-      We're looking for **21 value-aligned builders** who know what they're doing and want to see more cool stuff built. We don't have any official requirements—we're very open and just want to be surrounded by people who are value-aligned.
+      We're looking for **21 value-aligned builders** who want to see more real things built. There are no formal requirements—just alignment and a bias to build.
 
       **The Ideal Participant**:
-      The ideal participant is an experienced builder who resonates with the Bitcoin ethos, can code independently, and is eager to explore the frontier. They are excited—rather than terrified—by the prospect of demoing half-baked prototypes, and they crave long, oxytocin-fueled walks and thrive on rapid feedback. They believe that freedom-tech is the moral imperative of our time, want to build the future they want to see, and are willing to be fully present and participate in the full program.
+      The ideal participant is an experienced builder who resonates with the Bitcoin ethos, can code independently, and is eager to explore the frontier. They are excited—rather than terrified—by the prospect of demoing half-baked prototypes, crave long, oxytocin-fueled walks, and thrive on rapid feedback. They believe that Freedom Tech is the moral imperative of our time, want to build the future they want to see, and are willing to be fully present for the full program.
 
-      **The Magic Formula**: When you bring 21 value-aligned people together in a place that's super Bitcoin-friendly, beautiful, and allows for spontaneous creation, magical things are bound to happen.
+      **The Magic Formula**: Bring 21 aligned people together in a place that is highly Bitcoin-friendly, beautiful, and conducive to spontaneous creation, and magical things are bound to happen.
 
       **The Goal**: We want to see awesome stuff being built, expand the impact that freedom tech can have, come up with new ideas and protocols, test them immediately, and have a good time while doing it.
     image: 'stay-weird.jpg'

--- a/src/content/concept/-index.md
+++ b/src/content/concept/-index.md
@@ -21,15 +21,15 @@ sections:
     content: |
       Sovereign Engineering rests on five fundamental pillars that create the conditions for meaningful collaboration:
 
-      **The Weekly Loop**: A steady show → talk → build rhythm that drives momentum and prevents perfectionism paralysis. Every week follows the same structure—a metronome for creativity.
+      **[The Weekly Loop](#weekly-loop)**: A steady show → talk → build rhythm that drives momentum and prevents perfectionism paralysis. Every week follows the same structure—a metronome for creativity.
 
-      **The Walks**: Moderate hikes that stimulate creative thought through "left foot, right foot, left brain, right brain" activation. Walking isn't downtime—it's moving R&D.
+      **[The Walks](#walks)**: Moderate hikes that stimulate creative thought through "left foot, right foot, left brain, right brain" activation. Walking isn't downtime—it's moving R&D.
 
-      **The Demo Days**: Where the rubber meets the road—every participant demos working code every week. Aggressively time-boxed with 6-minute demos and 2-minute discussions.
+      **[The Demo Days](#demo-day)**: Where the rubber meets the road—every participant demos working code every week. Aggressively time-boxed with 6-minute demos and 2-minute discussions.
 
-      **The Captains**: Each week has a dedicated captain who steers the ship, ensuring organic emergence rather than top-down direction. Rotating leadership keeps the program tight without feeling top-down.
+      **[The Captains](#weekly-captains)**: Each week has a dedicated captain who steers the ship, ensuring organic emergence rather than top-down direction. Rotating leadership keeps the program tight without feeling top-down.
 
-      **The Environment**: Madeira makes ideas tangible fast—Bitcoin-friendly merchants, high-bandwidth in-person time, and an off-the-record space for bold exploration. Privacy, presence, and immediacy compound.
+      **[The Environment](#environment)**: Madeira makes ideas tangible fast—Bitcoin-friendly merchants, high-bandwidth in-person time, and an off-the-record space for bold exploration. Privacy, presence, and immediacy compound.
     image: '2-hours-of-conversation.jpeg'
 
   - id: 'weekly-loop'

--- a/src/content/concept/-index.md
+++ b/src/content/concept/-index.md
@@ -58,7 +58,7 @@ sections:
 
       **The Philosophy**: We highly encourage trying bold ideas every week. It doesn't matter if it's half-broken or half-baked—just give it your best shot and show it on Friday. The point is to ship thin vertical slices and learn fast.
 
-      **The Celebration**: After demos, we have a [beefsteak-style](https://archive.is/S3LjP) standing barbecue (no pre-arranged seating) that encourages natural group mixing. Friends and family are invited to join, creating a bridge between the private program and the broader community.
+      **The Celebration**: After demos, we have a [beefsteak-style](https://archive.is/S3LjP) standing barbecue (no pre-arranged seating) that invites relaxed, free-flowing conversation. Friends and family are invited to join, creating a bridge between the private program and the broader community.
 
       **The Impact**: Demo Day serves as a public ledger of progress. Six Fridays equal six checkpoints, creating proof-of-work encoded in weekly commits that prospective participants can review.
     image: 'demo-day.jpeg'
@@ -75,7 +75,7 @@ sections:
 
       **The Rotation**: By rotating leadership every week, the cohort practices the very autonomy it preaches. Leadership is shared, logistics are decentralized, and the program stays tight without feeling top-down.
 
-      **The Exception**: One week (week 4 or 5) is designated as "time off" because the program is quite intense. We learned over time that we need this break.
+      **The Exception**: Week 4 is designated as "time off" because the program is quite intense. We learned over time that we need this break.
     image: 'weekly-loop-schedule.png'
 
   - id: 'environment'

--- a/src/content/concept/-index.md
+++ b/src/content/concept/-index.md
@@ -21,15 +21,15 @@ sections:
     content: |
       Sovereign Engineering rests on five fundamental pillars that create the conditions for magical collaboration:
 
-      **The Weekly Loop**: The relentless show → talk → build rhythm that drives momentum and prevents perfectionism paralysis. Every week follows the same structure, creating a metronome for creativity.
+      **The Weekly Loop**: The relentless show → talk → build rhythm that drives momentum and prevents perfectionism paralysis. Every week follows the same structure—a metronome for creativity.
 
       **The Walks**: Moderate hikes that stimulate creative thought through "left foot, right foot, left brain, right brain" activation. Walking isn't downtime—it's moving R&D.
 
-      **Friday Demo Days**: Where the rubber meets the road—every participant demos working code every week. Aggressively time-boxed with 6-minute demos and 2-minute discussions.
+      **The Demo Days**: Where the rubber meets the road—every participant demos working code every week. Aggressively time-boxed with 6-minute demos and 2-minute discussions.
 
-      **Six Captains**: Each week has a dedicated captain who steers the ship, ensuring organic emergence rather than top-down direction. Rotating leadership keeps the program tight without feeling top-down.
+      **The Captains**: Each week has a dedicated captain who steers the ship, ensuring organic emergence rather than top-down direction. Rotating leadership keeps the program tight without feeling top-down.
 
-      **In-Person Intensity**: Being physically present on a remote island creates the commitment and focus needed for deep work. High-bandwidth communication, trust building, and ideation only work in person.
+      **The Environment**: Madeira makes ideas tangible fast—Bitcoin-friendly merchants, high-bandwidth in-person time, and an off-the-record space for bold exploration. Privacy, presence, and immediacy compound.
     image: '2-hours-of-conversation.jpeg'
 
   - id: 'weekly-loop'
@@ -56,7 +56,7 @@ sections:
     float: 'right'
 
   - id: 'demo-day'
-    title: 'Friday: Demo Day'
+    title: 'The Demo Days'
     content: |
       Nothing concentrates the mind like a live demo. Every Friday afternoon the cohort gathers to **show whatever runs**. Polish is optional, honesty is mandatory. The rule is simple: you must demo something new every week—either related to ongoing work or completely fresh ideas.
 
@@ -69,22 +69,10 @@ sections:
       **The Impact**: Demo Day serves as a public ledger of progress. Six Fridays equal six checkpoints, creating proof-of-work encoded in weekly commits that prospective participants can review.
     image: 'demo-day.jpeg'
 
-  - id: 'in-person-off-record'
-    title: 'In Person, Off the Record'
-    content: |
-      This is a **private, off-the-record event**—a core principle that cannot be overstated. You cannot do proper thinking completely out in the open. You have to be able to think in private and communicate in private without worrying about the online mob coming after you for having a crazy, weird, or stupid idea.
-
-      **Why Privacy Matters**: We want to build out in the open and care deeply about open source, but ideation and experimentation require a safe space. You only want criticism from people who are actually on your side—otherwise you might destroy a gem of an idea too early.
-
-      **The Experience**: We've learned this through hard experience. Bringing outside people into the group too early destroys the dynamic and trust built over weeks. The private space allows for unconstrained thinking and the discussion of more radical ideas.
-
-      **The Balance**: Once ideas are robust, they're exported to the open sea—published on Nostr, open-sourced on GitHub, or demoed publicly. The off-record space ensures critique targets the work, not internet clout.
-
-      **Presence**: We encourage participants to be fully present—leave phones at home or put them in airplane mode. If an idea is really good, you won't need to write it down—it will stay with you or someone else will remember it.
-    image: 'opt-out.jpg'
+  
 
   - id: 'weekly-captains'
-    title: '6 Weeks, 6 Captains'
+    title: 'The Captains'
     content: |
       Each week has a dedicated captain who steers the ship through that week's journey, ensuring organic emergence rather than top-down direction.
 
@@ -96,19 +84,17 @@ sections:
       **The Exception**: One week (week 4 or 5) is designated as "time off" because the program is quite intense. We learned over time that we need this break.
     image: 'weekly-loop-schedule.png'
 
-  - id: 'madeira-bitcoin'
-    title: 'Madeira: The Bitcoin Island'
+  - id: 'environment'
+    title: 'The Environment'
     image: 'madeira.jpg'
     content: |
-      Madeira isn't just a beautiful location—it's a **Bitcoin-friendly breeding ground** for the future. Thanks to the efforts of André and FREE Madeira, there are 150+ merchants on the island accepting Bitcoin. Paying in Bitcoin is so normal here that you barely think about it.
+      Madeira isn't just beautiful—it's a **Bitcoin-friendly proving ground**. Thanks to the efforts of André and FREE Madeira, there are 150+ merchants accepting Bitcoin. Paying in sats is normal.
 
-      **The Alpha Test Experience**: Build a new wallet on Thursday, then go to a coffee shop on Friday and pay with the wallet you built yesterday. It works—and it's an amazing feeling. In some ways, you can alpha test the future in Madeira.
+      **Off the Record, In Person**: We combine high-bandwidth in-person time with a private, off-the-record space. That safety lets wild ideas breathe before they ship to the open sea.
 
-      **The Filter Effect**: You can't just swing by and leave—you have to fly there. This creates a natural filter ensuring participants are committed to the full six-week experience.
+      **Alpha-Testing the Future**: Build a wallet on Thursday, pay with it on Friday. Hardware, merchants, and curious peers live within walking distance, collapsing the feedback loop.
 
-      **The Environment**: Madeira is a volcanic island with a subtropical climate, dark volcanic cliffs, and breathtaking topography. It's a magical place that enables spontaneous creation and the spawning of new ideas.
-
-      **The Community**: There are many Bitcoiners on the island, and merchant adoption is through the roof. It's a fantastic place to run a Sovereign Engineering cohort because it's highly Bitcoin-friendly and allows immediate testing of new protocols and tools.
+      **The Filter and the Place**: You have to fly here and commit for six weeks—a natural filter. The volcanic island, subtropical climate, and dramatic topography spark spontaneous creation.
 
   - id: 'target-audience'
     title: 'Who Should Apply?'

--- a/src/content/concept/-index.md
+++ b/src/content/concept/-index.md
@@ -11,7 +11,7 @@ intro:
 
       The program runs on a relentless [weekly loop](/loop) designed for exploration: Monday orientation sets the theme, *Tuesday Talks* provoke discussion, *Wednesday Workshops* transfer hands-on skills, *Thursday* offers time for reflection and experimentation, and by Friday's Demo Day every participant has completed an entire **show → talk → build** loop—ready to reset and do it again the following week.
 
-      The program is **private and off the record**—a safe space where 21 value-aligned builders can think freely, experiment boldly, and ship rapidly without the constraints of public scrutiny. Bring 21 aligned people together in a place that is highly Bitcoin-friendly, beautiful, and conducive to spontaneous creation, and remarkable things follow.
+      The program is **private and off the record**—a safe space where 21 value-aligned builders can think freely, experiment boldly, and ship rapidly without the constraints of public scrutiny. Bring 21 aligned people together in a place that is highly Bitcoin-friendly and beautiful, where a shift in perspective helps new ideas flourish—and remarkable things follow.
   image: 'www-life-path.png'
 
 # Concept sections
@@ -88,7 +88,7 @@ sections:
 
       **Alpha-Testing the Future**: Build a wallet on Thursday, pay with it on Friday. Hardware, merchants, and curious peers live within walking distance, collapsing the feedback loop.
 
-      **The Filter and the Place**: You have to fly here and commit for six weeks—a natural filter. The volcanic island, subtropical climate, and dramatic topography spark spontaneous creation.
+      **The Filter and the Place**: You have to fly here and commit for six weeks—a natural filter. The volcanic island, subtropical climate, and dramatic topography create the space for fresh perspectives and new ideas to emerge.
 
   - id: 'target-audience'
     title: 'Who Should Apply?'
@@ -98,7 +98,7 @@ sections:
       **The Ideal Participant**:
       The ideal participant is an experienced builder who resonates with the Bitcoin ethos, can code independently, and is eager to explore the frontier. They are excited—rather than terrified—by the prospect of demoing half-baked prototypes, crave long, oxytocin-fueled walks, and thrive on rapid feedback. They believe that Freedom Tech is the moral imperative of our time, want to build the future they want to see, and are willing to be fully present for the full program.
 
-      **The Magic Formula**: Bring 21 aligned people together in a place that is highly Bitcoin-friendly, beautiful, and conducive to spontaneous creation, and magical things are bound to happen.
+      **The Magic Formula**: Bring 21 aligned people together in a place that is highly Bitcoin-friendly and beautiful, and you get the perspective shift needed for new ideas to take root.
 
       **The Goal**: We want to see awesome stuff being built, expand the impact that freedom tech can have, come up with new ideas and protocols, test them immediately, and have a good time while doing it.
     image: 'stay-weird.jpg'

--- a/src/content/concept/-index.md
+++ b/src/content/concept/-index.md
@@ -11,7 +11,7 @@ intro:
 
       The program runs on a relentless [weekly loop](/loop) designed for exploration: Monday orientation sets the theme, *Tuesday Talks* provoke discussion, *Wednesday Workshops* transfer hands-on skills, *Thursday* offers time for reflection and experimentation, and by Friday's Demo Day every participant has completed an entire **show → talk → build** loop—ready to reset and do it again the following week.
 
-      The program is **private and off the record**—a safe space where 21 value-aligned builders can think freely, experiment boldly, and ship rapidly without the constraints of public scrutiny. Bring 21 aligned people together in a place that is highly Bitcoin-friendly, beautiful, and conducive to spontaneous creation, and magical things follow.
+      The program is **private and off the record**—a safe space where 21 value-aligned builders can think freely, experiment boldly, and ship rapidly without the constraints of public scrutiny. Bring 21 aligned people together in a place that is highly Bitcoin-friendly, beautiful, and conducive to spontaneous creation, and remarkable things follow.
   image: 'www-life-path.png'
 
 # Concept sections
@@ -19,9 +19,9 @@ sections:
   - id: 'core-pillars'
     title: 'Core Pillars'
     content: |
-      Sovereign Engineering rests on five fundamental pillars that create the conditions for magical collaboration:
+      Sovereign Engineering rests on five fundamental pillars that create the conditions for meaningful collaboration:
 
-      **The Weekly Loop**: The relentless show → talk → build rhythm that drives momentum and prevents perfectionism paralysis. Every week follows the same structure—a metronome for creativity.
+      **The Weekly Loop**: A steady show → talk → build rhythm that drives momentum and prevents perfectionism paralysis. Every week follows the same structure—a metronome for creativity.
 
       **The Walks**: Moderate hikes that stimulate creative thought through "left foot, right foot, left brain, right brain" activation. Walking isn't downtime—it's moving R&D.
 

--- a/src/content/concept/-index.md
+++ b/src/content/concept/-index.md
@@ -21,15 +21,15 @@ sections:
     content: |
       Sovereign Engineering rests on five fundamental pillars that create the conditions for meaningful collaboration:
 
-      **[The Weekly Loop](/loop#weekly-loop)**: A steady show → talk → build rhythm that drives momentum and prevents perfectionism paralysis. Every week follows the same structure—a metronome for creativity.
+      **[The Weekly Loop](#weekly-loop)**: A steady show → talk → build rhythm that drives momentum and prevents perfectionism paralysis. Every week follows the same structure—a metronome for creativity.
 
-      **[The Walks](/loop#walks)**: Moderate hikes that stimulate creative thought through "left foot, right foot, left brain, right brain" activation. Walking isn't downtime—it's moving R&D.
+      **[The Walks](#walks)**: Moderate hikes that stimulate creative thought through "left foot, right foot, left brain, right brain" activation. Walking isn't downtime—it's moving R&D.
 
-      **[The Demo Days](/loop#demo-day)**: Where the rubber meets the road—every participant demos working code every week. Aggressively time-boxed with 6-minute demos and 2-minute discussions.
+      **[The Demo Days](#demo-day)**: Where the rubber meets the road—every participant demos working code every week. Aggressively time-boxed with 6-minute demos and 2-minute discussions.
 
-      **[The Captains](/loop#captains)**: Each week has a dedicated captain who steers the ship, ensuring organic emergence rather than top-down direction. Rotating leadership keeps the program tight without feeling top-down.
+      **[The Captains](#weekly-captains)**: Each week has a dedicated captain who steers the ship, ensuring organic emergence rather than top-down direction. Rotating leadership keeps the program tight without feeling top-down.
 
-      **[The Environment](/loop#environment)**: Madeira makes ideas tangible fast—Bitcoin-friendly merchants, high-bandwidth in-person time, and an off-the-record space for bold exploration. Privacy, presence, and immediacy compound.
+      **[The Environment](#environment)**: Madeira makes ideas tangible fast—Bitcoin-friendly merchants, high-bandwidth in-person time, and an off-the-record space for bold exploration. Privacy, presence, and immediacy compound.
     image: '2-hours-of-conversation.jpeg'
 
   - id: 'weekly-loop'

--- a/src/content/homepage/-index.md
+++ b/src/content/homepage/-index.md
@@ -46,11 +46,11 @@ features:
     content: 'The program is powered by five core pillars that create the conditions for meaningful collaboration and rapid prototyping.'
     weeklyRhythm: true
     bulletpoints:
-      - '**In-Person Intensity**: Physical presence on Madeira creates deep focus'
-      - '**The Weekly Loop**: Show → Talk → Build rhythm that drives momentum'
-      - '**The Walks**: Moderate hikes for creative thought and free-flowing conversations'
-      - '**Six Captains**: Rotating leadership keeps the program organic, not top-down'
-      - '**Friday Demo Days**: Every participant demos working code every week'
+      - '**[In-Person Intensity](/loop#in-person-intensity)**: Physical presence on Madeira creates deep focus'
+      - '**[The Weekly Loop](/loop#weekly-loop)**: Show → Talk → Build rhythm that drives momentum'
+      - '**[The Walks](/loop#walks)**: Moderate hikes for creative thought and free-flowing conversations'
+      - '**[Six Captains](/loop#captains)**: Rotating leadership keeps the program organic, not top-down'
+      - '**[Friday Demo Days](/loop#demo-day)**: Every participant demos working code every week'
     button:
       enable: true
       label: 'Learn Our Concept'

--- a/src/content/homepage/-index.md
+++ b/src/content/homepage/-index.md
@@ -43,7 +43,7 @@ features:
 
   - title: 'How does it work?'
     image: '/images/map.png'
-    content: 'The program is powered by five core pillars that create the conditions for magical collaboration and rapid prototyping.'
+    content: 'The program is powered by five core pillars that create the conditions for meaningful collaboration and rapid prototyping.'
     weeklyRhythm: true
     bulletpoints:
       - '**In-Person Intensity**: Physical presence on Madeira creates deep focus'

--- a/src/content/homepage/-index.md
+++ b/src/content/homepage/-index.md
@@ -13,7 +13,7 @@ banner:
 features:
   - title: 'Why Sovereign Engineering?'
     image: '/images/boat2.png'
-    content: 'We love the internet—it is one of the most important inventions in human history and essential for a free, flourishing society. But parts of today\'s web are failing us. Bitcoin and Nostr point toward a healthier architecture: open, permissionless, and user-sovereign.'
+    content: 'We love the internet—it is one of the most important inventions in human history and essential for a free, flourishing society. But parts of today''s web are failing us. Bitcoin and Nostr point toward a healthier architecture: open, permissionless, and user-sovereign.'
     bulletpoints:
       - 'Build systems in the spirit of Bitcoin'
       - 'Focus on value-aligned technologies'

--- a/src/content/homepage/-index.md
+++ b/src/content/homepage/-index.md
@@ -46,11 +46,11 @@ features:
     content: 'The program is powered by five core pillars that create the conditions for meaningful collaboration and rapid prototyping.'
     weeklyRhythm: true
     bulletpoints:
-      - '**[In-Person Intensity](/loop#in-person-intensity)**: Physical presence on Madeira creates deep focus'
-      - '**[The Weekly Loop](/loop#weekly-loop)**: Show → Talk → Build rhythm that drives momentum'
-      - '**[The Walks](/loop#walks)**: Moderate hikes for creative thought and free-flowing conversations'
-      - '**[Six Captains](/loop#captains)**: Rotating leadership keeps the program organic, not top-down'
-      - '**[Friday Demo Days](/loop#demo-day)**: Every participant demos working code every week'
+      - '**In-Person Intensity**: Physical presence on Madeira creates deep focus'
+      - '**The Weekly Loop**: Show → Talk → Build rhythm that drives momentum'
+      - '**The Walks**: Moderate hikes for creative thought and free-flowing conversations'
+      - '**Six Captains**: Rotating leadership keeps the program organic, not top-down'
+      - '**Friday Demo Days**: Every participant demos working code every week'
     button:
       enable: true
       label: 'Learn Our Concept'

--- a/src/content/homepage/-index.md
+++ b/src/content/homepage/-index.md
@@ -15,8 +15,8 @@ features:
     image: '/images/boat2.png'
     content: 'We love the internet—it is one of the most important inventions in human history and essential for a free, flourishing society. But parts of today''s web are failing us. Bitcoin and Nostr point toward a healthier architecture: open, permissionless, and self-sovereign.'
     bulletpoints:
-      - 'Build systems in the spirit of Bitcoin'
       - 'Focus on value-aligned technologies'
+      - 'Build systems in the spirit of Bitcoin'
       - 'Create the future of self-sovereign applications'
       - 'Escape the attention economy and parasitic web models'
       - 'Design for censorship resistance and permissionless access'

--- a/src/content/homepage/-index.md
+++ b/src/content/homepage/-index.md
@@ -20,7 +20,7 @@ features:
       - 'Create the future of self-sovereign applications'
       - 'Escape the attention economy and parasitic web models'
       - 'Design for censorship resistance and permissionless access'
-      - 'Build cool shit that actually gets shipped and used'
+      - 'Build cool shit that actually gets shipped and used. No shitcoins.'
     button:
       enable: true
       label: 'Read our philosophy'

--- a/src/content/homepage/-index.md
+++ b/src/content/homepage/-index.md
@@ -13,7 +13,7 @@ banner:
 features:
   - title: 'Why Sovereign Engineering?'
     image: '/images/boat2.png'
-    content: 'We believe the internet is broken and we can do better. Bitcoin and nostr have crucial roles to play in fixing the Web and building a self-sovereign future.'
+    content: 'We love the internet—it is one of the most important inventions in human history and essential for a free, flourishing society. But parts of today\'s web are failing us. Bitcoin and Nostr point toward a healthier architecture: open, permissionless, and user-sovereign.'
     bulletpoints:
       - 'Build systems in the spirit of Bitcoin'
       - 'Focus on value-aligned technologies'

--- a/src/content/homepage/-index.md
+++ b/src/content/homepage/-index.md
@@ -13,7 +13,7 @@ banner:
 features:
   - title: 'Why Sovereign Engineering?'
     image: '/images/boat2.png'
-    content: 'We love the internet—it is one of the most important inventions in human history and essential for a free, flourishing society. But parts of today''s web are failing us. Bitcoin and Nostr point toward a healthier architecture: open, permissionless, and user-sovereign.'
+    content: 'We love the internet—it is one of the most important inventions in human history and essential for a free, flourishing society. But parts of today''s web are failing us. Bitcoin and Nostr point toward a healthier architecture: open, permissionless, and self-sovereign.'
     bulletpoints:
       - 'Build systems in the spirit of Bitcoin'
       - 'Focus on value-aligned technologies'

--- a/src/content/loop/-index.md
+++ b/src/content/loop/-index.md
@@ -2,12 +2,12 @@
 # Loop Page Content
 title: 'The Weekly Loop'
 meta_title: 'THE WEEKLY LOOP'
-description: 'The relentless show → talk → build rhythm that drives momentum and prevents perfectionism paralysis'
+description: 'The steady show → talk → build rhythm that drives momentum and prevents perfectionism paralysis'
 
 # Main introduction section
 intro:
   content: |
       The week acts as a metronome for creativity. Friday's *Show* sets a hard deadline that concentrates effort—every participant demos something they wrote or prompted into existence themselves. The moment code compiles on stage it becomes shared reality. Over the weekend and during Monday's orientation the cohort *Talks*—walking Madeira's levadas, swapping critiques, and letting distributed cognition surface better approaches. From Tuesday onward everyone *Builds* toward the next demo.
 
-      This relentless rhythm prevents perfectionism paralysis and creates the conditions for collaboration. Every week follows the same structure, creating a predictable cadence that lets participants focus on what matters: building and shipping real projects.
+      This steady rhythm prevents perfectionism paralysis and creates the conditions for collaboration. Every week follows the same structure, creating a predictable cadence that lets participants focus on what matters: building and shipping real projects.
 --- 

--- a/src/content/loop/-index.md
+++ b/src/content/loop/-index.md
@@ -7,7 +7,7 @@ description: 'The relentless show → talk → build rhythm that drives momentum
 # Main introduction section
 intro:
   content: |
-    The week acts as a metronome for creativity. Friday's *Show* sets a hard deadline that concentrates effort—every participant must demo something they wrote or prompted into existence themselves. The moment code compiles on stage it becomes shared reality. Over the weekend and during Monday's orientation the cohort *Talks*—walking Madeira's levadas, swapping critiques, and letting distributed cognition surface better approaches. From Tuesday onwards everyone *Builds* toward the next demo.
+      The week acts as a metronome for creativity. Friday's *Show* sets a hard deadline that concentrates effort—every participant demos something they wrote or prompted into existence themselves. The moment code compiles on stage it becomes shared reality. Over the weekend and during Monday's orientation the cohort *Talks*—walking Madeira's levadas, swapping critiques, and letting distributed cognition surface better approaches. From Tuesday onward everyone *Builds* toward the next demo.
 
-    This relentless rhythm prevents perfectionism paralysis and creates the conditions for magical collaboration. Every week follows the same structure, creating a predictable cadence that allows participants to focus on what matters: building and shipping real projects.
+      This relentless rhythm prevents perfectionism paralysis and creates the conditions for collaboration. Every week follows the same structure, creating a predictable cadence that lets participants focus on what matters: building and shipping real projects.
 --- 

--- a/src/content/philosophy/-index.md
+++ b/src/content/philosophy/-index.md
@@ -8,7 +8,7 @@ description: 'Our philosophy and principles'
 intro:
   quote_section: 'Philosophy' # References philosophy-quotes.json
   content: |
-    Sovereign Engineering is grounded in the values embodied by Bitcoin: **self-sovereignty, user agency, and censorship-resistance**. We build technology that maximises individual freedom, minimises reliance on trusted third parties, and treats the individual as the ultimate node in every network.
+    Sovereign Engineering is grounded in the values embodied by Bitcoin: **self-sovereignty, user agency, and censorship-resistance**. We build technology that maximizes individual freedom, minimizes reliance on trusted third parties, and treats the individual as the ultimate authority in every network.
 
     From ["Fix the Money, Fix the Web"](https://njump.me/nevent1qqsqm2lz4ru6wlydzpulgs8m60ylp4vufwsg55whlqgua6a93vp2y4gpzamhxue69uhhyetvv9ujuer9wfnkjemf9e3k7mgzyphydppzm7m554ecwq4gsgaek2qk32atse2l4t9ks57dpms4mmhfxjc476g) we take the conviction that a sound monetary foundation is a moral imperative, and that Bitcoin's paradigm of extreme ownership demands equally sovereign applications. Likewise, [Nostr](https://nostr-resources.com/) reminds us that protocols, not platforms, will reclaim the vibrant, open experimentation that defined the early web.
   image: 'pirate-ship-2.jpeg'

--- a/src/content/philosophy/-index.md
+++ b/src/content/philosophy/-index.md
@@ -8,7 +8,7 @@ description: 'Our philosophy and principles'
 intro:
   quote_section: 'Philosophy' # References philosophy-quotes.json
   content: |
-    Sovereign Engineering is grounded in the values embodied by Bitcoin: **self-sovereignty, agency, and censorship-resistance**. We build technology that maximises individual freedom, minimises reliance on trusted third parties, and treats the individual as the ultimate node in every network.
+    Sovereign Engineering is grounded in the values embodied by Bitcoin: **self-sovereignty, user agency, and censorship-resistance**. We build technology that maximises individual freedom, minimises reliance on trusted third parties, and treats the individual as the ultimate node in every network.
 
     From ["Fix the Money, Fix the Web"](https://njump.me/nevent1qqsqm2lz4ru6wlydzpulgs8m60ylp4vufwsg55whlqgua6a93vp2y4gpzamhxue69uhhyetvv9ujuer9wfnkjemf9e3k7mgzyphydppzm7m554ecwq4gsgaek2qk32atse2l4t9ks57dpms4mmhfxjc476g) we take the conviction that a sound monetary foundation is a moral imperative, and that Bitcoin's paradigm of extreme ownership demands equally sovereign applications. Likewise, [Nostr](https://nostr-resources.com/) reminds us that protocols, not platforms, will reclaim the vibrant, open experimentation that defined the early web.
   image: 'pirate-ship-2.jpeg'

--- a/src/content/philosophy/-index.md
+++ b/src/content/philosophy/-index.md
@@ -103,6 +103,7 @@ sections:
     quote_section: 'Endurance' # References philosophy-quotes.json
     image: 'endurance.jpeg'
     float: 'left'
+    link: '/books'
     content: |
       Building self-sovereign systems is a **marathon**, not a sprint; endurance and steady iteration win the day.
 

--- a/src/content/philosophy/-index.md
+++ b/src/content/philosophy/-index.md
@@ -21,23 +21,23 @@ sections:
     image: 'genesis-block.png'
     float: 'right'
     content: |
-      Bitcoin, Lightning, and Nostr prove that code can embed freedom at the protocol layer: freedom of speech, assembly, movement, and of course financial freedom.  We strive to reproduce that super-power in every system we touch, so that liberty is enforced by mathematics rather than maintained by promises.
+      Bitcoin, Lightning, and Nostr prove that code can embed freedom at the protocol layer: speech, assembly, movement—and of course financial freedom. We strive to reproduce that superpower in every system we touch, so liberty is enforced by mathematics rather than maintained by promises.
 
-      Good design begins with values.  We minimise dependencies, maximise verifiability, and keep exit-costs asymptotically close to zero. When the design is right, freedom is a property—not a permission.
+      Good design begins with values. We minimize dependencies, maximize verifiability, and keep exit costs asymptotically close to zero. When the design is right, freedom is a property—not a permission.
 
-      This way of thinking is what we call *Freedom Tech*: technology that is rugpull-resistant by design.  When betrayal is impossible, trust becomes optional and collaboration scales.
+      This way of thinking is what we call *Freedom Tech*: technology that is rug-pull-resistant by design. When betrayal is impossible, trust becomes optional and collaboration scales.
 
   - id: 'solved-by-walking'
-    title: 'Solved By Walking'
+    title: 'Solved by Walking'
     quote_section: 'Solved By Walking' # References philosophy-quotes.json
     image: 'solvitur-ambulando.jpeg'
     float: 'left'
     content: |
-      No ill-defined problem was ever solved in isolation.  By gathering bright minds in a high-trust setting we tap into what cognitive scientist [John Vervaeke](https://johnvervaeke.com/series/awakening-from-the-meaning-crisis/) calls *distributed cognition*.  Ideas bounce, mutate, and compound until entirely new solution-spaces appear.
+      No ill-defined problem was ever solved in isolation. By gathering bright minds in a high-trust setting we tap into what cognitive scientist [John Vervaeke](https://johnvervaeke.com/series/awakening-from-the-meaning-crisis/) calls *distributed cognition*. Ideas bounce, mutate, and compound until entirely new solution-spaces appear.
 
-      The fuel for that process is conversation, and the best conversations happen while *walking*.  Saint Augustine called it *Solvitur ambulando*—"by walking it shall be solved." Madeira's levadas offer kilometres of cognitive runway.
+      The fuel for that process is conversation, and the best conversations happen while *walking*. Saint Augustine called it *Solvitur ambulando*—"by walking it shall be solved." Madeira's levadas offer kilometers of cognitive runway.
 
-      Friday's Demo Day then serves as an epistemic checkpoint.  Six minutes to show, two to discuss.  Brutal, illuminating, and endlessly inspiring.
+      Friday's Demo Day serves as an epistemic checkpoint. Six minutes to show, two to discuss. Brutal, illuminating, and endlessly inspiring.
 
   - id: 'explorers-of-a-new-frontier'
     title: 'Explorers of a New Frontier'
@@ -49,7 +49,7 @@ sections:
 
       Like Shackleton's crew, participants must trust one another when storms hit, and celebrate together when new land appears on the horizon. The sea is vast, and so is the opportunity.
 
-      Those who prefer calm harbours and predictable schedules need not apply.  We are optimised for the pirates, the adventurers, and the stubborn optimists who believe the internet can still astonish us.
+      Those who prefer calm harbors and predictable schedules need not apply. We are optimized for the pirates, the adventurers, and the stubborn optimists who believe the internet can still astonish us.
 
   - id: 'in-person-high-bandwidth'
     title: 'In-Person, High-Bandwidth'
@@ -70,13 +70,13 @@ sections:
     float: 'right'
     link: '/concept'
     content: |
-      We prototype first, critique later. Imperfect code is welcomed if it advances the conversation. Novelty, experimentation, and rapid iteration trump premature optimisation.
+      We prototype first, critique later. Imperfect code is welcomed if it advances the conversation. Novelty, experimentation, and rapid iteration trump premature optimization.
 
       This bias for action produces tangible results: from *Blossom* to *ZapStore*, many [cohort projects](/projects) were conceived on a Monday walk and open-sourced before the next weekend. The world needs working code, not slide decks.
 
-      Direction beats speed, yet speed still helps.  We chase the 80-20, knowing that the last 20 % can wait until the idea survives first contact with reality.
+      Direction beats speed, yet speed still helps. We chase the 80–20, knowing that the last 20% can wait until the idea survives first contact with reality.
 
-      Want to see how this rapid loop plays out week-by-week? Explore the full cadence in our [Concept](/concept) section.
+      Want to see how this rapid loop plays out week by week? Explore the full cadence in our [Concept](/concept) section.
 
   - id: 'cypherpunks-write-code'
     title: 'Cypherpunks Write Code'
@@ -84,9 +84,9 @@ sections:
     image: 'cypherpunks-write-code.jpeg'
     float: 'left'
     content: |
-      *"What does it mean to 'build it right'?"* ask Pablo & Gigi. It means writing code that the user can verify, fork, and *exit* from; choosing architectures that minimise trust; and favouring primitives that stand the test of decades.
+      *"What does it mean to 'build it right'?"* ask Pablo & Gigi. It means writing code that the user can verify, fork, and *exit* from; choosing architectures that minimize trust; and favoring primitives that stand the test of decades.
 
-      Hal Finney's challenge calls for code that stands on its own—transparent, user-verifiable, and resilient to adversarial pressure.  We prize lean binaries, readable source, and simple dependency graphs so every sailor on this digital ocean can audit the hull before they board.
+      Hal Finney's challenge calls for code that stands on its own—transparent, user-verifiable, and resilient to adversarial pressure. We prize lean binaries, readable source, and simple dependency graphs so every sailor on this digital ocean can audit the hull before they board.
 
   - id: 'no-solutions'
     title: 'No Solutions'
@@ -94,7 +94,7 @@ sections:
     image: 'wide-open-sea.jpeg'
     float: 'right'
     content: |
-      Our craft is the art of choosing the right compromises—those that maximise sovereignty, minimise trust, and preserve optionality for generations of builders to come.
+      Our craft is the art of choosing the right compromises—those that maximize sovereignty, minimize trust, and preserve optionality for generations of builders to come.
 
       The [No Solutions podcast](https://castr.me/npub1n00yy9y3704drtpph5wszen64w287nquftkcwcjv7gnnkpk2q54s73000n) is our experiment in *Dia-Logos*—capturing the same free-flowing, exploratory conversations that spark during every cohort and pressing record.
 
@@ -106,9 +106,9 @@ sections:
     content: |
       Building self-sovereign systems is a **marathon**, not a sprint; endurance and steady iteration win the day.
 
-      Freedom Tech is not built in fiscal quarters; it is forged across decades.  We favour antifragile tooling, small teams, and battle-tested primitives that will still compile when our grandchildren fork the repo.
+      Freedom Tech is not built in fiscal quarters; it is forged across decades. We favor antifragile tooling, small teams, and battle-tested primitives that will still compile when our grandchildren fork the repo.
 
-      We endure because the mission matters: **fix the money, fix the internet**.  Everything else is a footnote.
+      We endure because the mission matters: **fix the money, fix the internet**. Everything else is a footnote.
 
 # Call to action
 cta:

--- a/src/content/philosophy/-index.md
+++ b/src/content/philosophy/-index.md
@@ -110,6 +110,8 @@ sections:
       Freedom Tech is not built in fiscal quarters; it is forged across decades. We favor antifragile tooling, small teams, and battle-tested primitives that will still compile when our grandchildren fork the repo.
 
       We endure because the mission matters: **fix the money, fix the internet**. Everything else is a footnote.
+    afterContent: |
+      <p class="mt-6 text-center"><a href="/concept">Next: Explore the Concept →</a></p>
 
 # Call to action
 cta:

--- a/src/content/philosophy/-index.md
+++ b/src/content/philosophy/-index.md
@@ -111,7 +111,7 @@ sections:
 
       We endure because the mission matters: **fix the money, fix the internet**. Everything else is a footnote.
     afterContent: |
-      <p class="mt-6 text-center"><a href="/concept">Next: Explore the Concept →</a></p>
+      <p class="mt-6"><a href="/concept">Next: Explore the Concept →</a></p>
 
 # Call to action
 cta:

--- a/src/data/weeklyRhythm.json
+++ b/src/data/weeklyRhythm.json
@@ -1,5 +1,5 @@
 {
-  "description": "Every week follows the same structure, a relentless show → talk → build rhythm designed to maximize creativity, collaboration, and shipping real projects. This cadence acts as a metronome for creativity, preventing perfectionism paralysis and creating the conditions for magical collaboration.",
+  "description": "Every week follows the same structure, a steady show → talk → build rhythm designed to maximize creativity, collaboration, and shipping real projects. This cadence acts as a metronome for creativity, preventing perfectionism paralysis and creating the conditions for meaningful collaboration.",
   "schedule": [
     {
       "day": "Monday Mornings",

--- a/src/data/weeklyRhythm.json
+++ b/src/data/weeklyRhythm.json
@@ -43,7 +43,7 @@
     },
     {
       "day": "Weekend Walks",
-      "short_description": "Hikes for natural group mixing and free-flowing conversations.",
+      "short_description": "Hikes to stimulate the group and foster free-flowing conversations.",
       "tagline": "Moving R&D & Natural Group Mixing",
       "goal": "Stimulate creative thought and facilitate the free flow of ideas through light physical activity and spontaneous, high-bandwidth conversations.",
       "description": "An absolutely crucial pillar of the program. Light-to-moderate 2-3 hour hikes on wide paths allow for natural group mixing and side-by-side conversations. Guided to ensure the group stays together, these walks are 'moving R&D' and the primary engine for ideation.",

--- a/src/layouts/components/ContentSection.astro
+++ b/src/layouts/components/ContentSection.astro
@@ -109,7 +109,7 @@ const processedAfterContent = afterContent ? await markdownify(afterContent) : n
                 {processedBulletPoints.map((bullet: string) => (
                   <li class="flex items-center mb-4 text-white text-lg">
                     <span class="mr-3 flex-shrink-0 text-white">&#10022;</span>
-                    <span set:html={bullet} class="text-lg [&_a]:text-lg [&_a]:text-white" />
+                    <span set:html={bullet} class="text-lg [&_a]:text-lg [&_a]:text-white [&_a]:underline [&_a]:decoration-2 [&_a]:underline-offset-2 hover:[&_a]:text-primary" />
                   </li>
                 ))}
               </ul>
@@ -152,7 +152,7 @@ const processedAfterContent = afterContent ? await markdownify(afterContent) : n
                 {processedBulletPoints.map((bullet: string) => (
                   <li class="flex items-center mb-4 text-white text-lg">
                     <span class="mr-3 flex-shrink-0 text-white">&#10022;</span>
-                    <span set:html={bullet} class="text-lg [&_a]:text-lg [&_a]:text-white" />
+                    <span set:html={bullet} class="text-lg [&_a]:text-lg [&_a]:text-white [&_a]:underline [&_a]:decoration-2 [&_a]:underline-offset-2 hover:[&_a]:text-primary" />
                   </li>
                 ))}
               </ul>

--- a/src/pages/concept.astro
+++ b/src/pages/concept.astro
@@ -24,6 +24,7 @@ import twoHoursConversationImage from "@/assets/images/2-hours-of-conversation.j
 import stayWeirdImage from "@/assets/images/stay-weird.jpg";
 import flowersImage from "@/assets/images/flowers.jpg";
 import wwwLifePathImage from "@/assets/images/www-life-path.png";
+import { slugify } from "@/lib/utils/textConverter";
 
 // Get concept content
 const concept = (await getEntry(
@@ -77,17 +78,15 @@ interface Section {
 const processedSections = sections.map(
   (section: Section) => {
   if (section.id === "weekly-loop") {
-    // Convert weekly rhythm schedule to bulletpoints
-    const scheduleBullets = weeklyRhythmData.schedule.map((item) =>
-      `**${item.day}** – ${item.short_description}`
-    );
-    // Create the "Learn More" link
-    const link = `**[Learn more about the weekly rhythm →](/loop)**`;
+    // Convert weekly rhythm schedule to bulletpoints with anchor links to /loop
+    const scheduleBullets = weeklyRhythmData.schedule.map((item) => {
+      const anchor = slugify(item.day);
+      return `**[${item.day}](/loop#${anchor})** – ${item.short_description}`;
+    });
 
     return {
       ...section,
       bulletpoints: scheduleBullets,
-      afterContent: link,
     };
   }
 

--- a/src/pages/loop.astro
+++ b/src/pages/loop.astro
@@ -93,7 +93,7 @@ const imageMap: Record<string, ImageMetadata | string> = {
   <!-- Next Link -->
   <section class="section-sm bg-black text-white">
     <div class="container">
-      <p class="mt-6"><a href="/projects" class="underline decoration-2 underline-offset-2 hover:text-primary">Next: Explore Demo Day Projects →</a></p>
+      <p class="mt-6"><a href="/podcast" class="underline decoration-2 underline-offset-2 hover:text-primary">Next: Listen to some of our conversations →</a></p>
     </div>
   </section>
 </Base>

--- a/src/pages/loop.astro
+++ b/src/pages/loop.astro
@@ -93,7 +93,7 @@ const imageMap: Record<string, ImageMetadata | string> = {
   <!-- Next Link -->
   <section class="section-sm bg-black text-white">
     <div class="container">
-      <p class="mt-6"><a href="/projects">Next: Explore Demo Day Projects →</a></p>
+      <p class="mt-6"><a href="/projects" class="underline decoration-2 underline-offset-2 hover:text-primary">Next: Explore Demo Day Projects →</a></p>
     </div>
   </section>
 </Base>

--- a/src/pages/loop.astro
+++ b/src/pages/loop.astro
@@ -89,4 +89,11 @@ const imageMap: Record<string, ImageMetadata | string> = {
       )
     }
   )}
+
+  <!-- Next Link -->
+  <section class="section-sm bg-black text-white">
+    <div class="container">
+      <p class="mt-6"><a href="/projects">Next: Explore Demo Day Projects →</a></p>
+    </div>
+  </section>
 </Base>

--- a/src/pages/philosophy.astro
+++ b/src/pages/philosophy.astro
@@ -55,6 +55,7 @@ interface Section {
   float: string;
   content: string;
   link?: string;
+  afterContent?: string;
 }
 ---
 
@@ -80,6 +81,7 @@ interface Section {
       content={section.content}
       image={slideMap[section.image]}
       index={index}
+      afterContent={section.afterContent}
       pullquote={{
         quote: getQuote(section.quote_section || "")?.quote || "",
         author: getQuote(section.quote_section || "")?.author || "",

--- a/src/pages/podcast.astro
+++ b/src/pages/podcast.astro
@@ -93,6 +93,12 @@ const pageDescription = "No Solutions podcast";
       <BigBlockQuote
         quote={metaQuote}
       />
+      <!-- Next Link -->
+      <section class="section-sm bg-black text-white">
+        <div class="container">
+          <p class="mt-6"><a href="/projects" class="underline decoration-2 underline-offset-2 hover:text-primary">Next: Explore Demo Day Projects →</a></p>
+        </div>
+      </section>
     </div>
   </section>
 </Base>

--- a/src/pages/podcast.astro
+++ b/src/pages/podcast.astro
@@ -96,7 +96,7 @@ const pageDescription = "No Solutions podcast";
       <!-- Next Link -->
       <section class="section-sm bg-black text-white">
         <div class="container">
-          <p class="mt-6"><a href="/projects" class="underline decoration-2 underline-offset-2 hover:text-primary">Next: Explore Demo Day Projects →</a></p>
+          <p class="mt-6"><a href="/projects" class="underline decoration-2 underline-offset-2 hover:text-primary">Next: Explore the projects we discuss →</a></p>
         </div>
       </section>
     </div>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -20,7 +20,7 @@ import showcaseProjects from "@/data/showcaseProjects.js";
   <!-- Next Link -->
   <section class="section-sm bg-black text-white">
     <div class="container">
-      <p class="mt-6"><a href="/podcast" class="underline decoration-2 underline-offset-2 hover:text-primary">Next: Listen to the No Solutions Podcast →</a></p>
+      <p class="mt-6"><a href="/podcast" class="underline decoration-2 underline-offset-2 hover:text-primary">Next: Listen to some of our conversations →</a></p>
     </div>
   </section>
 </Base>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -17,10 +17,5 @@ import showcaseProjects from "@/data/showcaseProjects.js";
     showHighlights={true}
   />
 
-  <!-- Next Link -->
-  <section class="section-sm bg-black text-white">
-    <div class="container">
-      <p class="mt-6"><a href="/podcast" class="underline decoration-2 underline-offset-2 hover:text-primary">Next: Listen to some of our conversations →</a></p>
-    </div>
-  </section>
+  <!-- No Next link here; flow handled from /podcast -->
 </Base>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -16,4 +16,11 @@ import showcaseProjects from "@/data/showcaseProjects.js";
     showTitle={true}
     showHighlights={true}
   />
+
+  <!-- Next Link -->
+  <section class="section-sm bg-black text-white">
+    <div class="container">
+      <p class="mt-6"><a href="/podcast">Next: Listen to the No Solutions Podcast →</a></p>
+    </div>
+  </section>
 </Base>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -20,7 +20,7 @@ import showcaseProjects from "@/data/showcaseProjects.js";
   <!-- Next Link -->
   <section class="section-sm bg-black text-white">
     <div class="container">
-      <p class="mt-6"><a href="/podcast">Next: Listen to the No Solutions Podcast →</a></p>
+      <p class="mt-6"><a href="/podcast" class="underline decoration-2 underline-offset-2 hover:text-primary">Next: Listen to the No Solutions Podcast →</a></p>
     </div>
   </section>
 </Base>


### PR DESCRIPTION
This PR refines site copy and improves page-to-page navigation.

- Tightens writing on Philosophy, Concept, and Loop pages; standardizes US z-spelling and replaces harsh or vague terms (e.g., steady vs relentless; meaningful vs magical)
- Adds contextual Next links and corrects flow: /philosophy → /concept → /loop → /podcast → /projects; links core-pillar bullets and weekly loop bullets to anchors
- Improves clarity around privacy (protected environment), walking descriptions, demo-day sections, and adds appropriate references (beefsteak-style)